### PR TITLE
The error from client.track will not always conform to our expectations.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,14 @@ function FedEx(args) {
           console.log(util.inspect(parser.toJson(client.lastRequest, {coerce: false, object: true, sanitize: false}), {depth: null}));
         }
         if(err) {
-          return callback(err.root.Envelope.Body.Fault, null);
+            try {
+                return callback(err.root.Envelope.Body.Fault, null);
+            } catch(e) {
+                if($scope.options.debug) {
+                    console.log(util.inspect(err));
+                }
+                return callback(err, null);
+            }
         }
 
         return callback(err, result);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "extend": "^1.2.1",
     "soap": "^0.8.0",
-    "xml2json": "~0.3.2"
+    "xml2json": "latest"
   }
 }


### PR DESCRIPTION
I was encountering a crash here when the error was an E_TIMEDOUT error instead of a SOAP error.  This is a quick and dirty patch to prevent this from becoming an issue.