### PR TITLE
Updated xml2json version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "extend": "^1.2.1",
     "soap": "^0.8.0",
-    "xml2json": "~0.3.2"
+    "xml2json": "~0.6.1"
   }
 }


### PR DESCRIPTION
The node-gyp build consistently fails with newer versions of nodejs, due to an apparently outdated xml2json version (I think related to its iconv version dependency). Pull request updates xml2json version to a more modern version, which fixes the install/compilation problem for me.

If possible, please commit pull request unless you know a good reason not to. If not, please commit an update that will allow me to do an npm install of your package on modern ubuntu + nodejs stack. Thank you, and thank you for this package!